### PR TITLE
Payment Types

### DIFF
--- a/src/components/ecommerce/EcommerceRouter.js
+++ b/src/components/ecommerce/EcommerceRouter.js
@@ -20,6 +20,7 @@ import ProductDetail from "./products/product_detail/product_detail"
 import ProductTypeDetail from "./product_types/product_type_detail/product_type_detail"
 import PaymentTypes from "./payment_types/paymentTypes"
 import PaymentTypeDetail from "./payment_types/paymentTypeDetail"
+import NewPaymentType from "./payment_types/newPaymentType"
 
 class EcommerceRouter extends Component {
   state = {  }
@@ -55,6 +56,7 @@ class EcommerceRouter extends Component {
           <Route exact path="/ecommerce/producttypes/:productTypeId(\d+)" render={(props)=> <ProductTypeDetail {...props}/>}/>
           <Route exact path="/ecommerce/paymenttypes" render={props => <PaymentTypes {...props} />} />
           <Route exact path="/ecommerce/paymenttypes/:paymentTypeId(\d+)" render={props => <PaymentTypeDetail {...props} />} />
+          <Route exact path="/ecommerce/paymenttypes/new" render={props => <NewPaymentType {...props} />} />
         </Switch>
       </>
     )

--- a/src/components/ecommerce/EcommerceRouter.js
+++ b/src/components/ecommerce/EcommerceRouter.js
@@ -18,6 +18,8 @@ import Products from "./products/products"
 import ProductTypes from "./product_types/product_types"
 import ProductDetail from "./products/product_detail/product_detail"
 import ProductTypeDetail from "./product_types/product_type_detail/product_type_detail"
+import PaymentTypes from "./payment_types/paymentTypes"
+import PaymentTypeDetail from "./payment_types/paymentTypeDetail"
 
 class EcommerceRouter extends Component {
   state = {  }
@@ -36,6 +38,9 @@ class EcommerceRouter extends Component {
             <NavItem>
               <NavLink tag={RouterNavLink} to="/ecommerce/producttypes">Product Types</NavLink>
             </NavItem>
+            <NavItem>
+              <NavLink tag={RouterNavLink} to="/ecommerce/paymenttypes">Payment Types</NavLink>
+            </NavItem>
           </Nav>
         </Navbar>
 
@@ -48,6 +53,8 @@ class EcommerceRouter extends Component {
           <Route exact path="/ecommerce/products/:productId(\d+)" render={(props)=> <ProductDetail {...props}/>}/>
           <Route exact path="/ecommerce/producttypes" render={(props) => <ProductTypes {...props}/>}/>
           <Route exact path="/ecommerce/producttypes/:productTypeId(\d+)" render={(props)=> <ProductTypeDetail {...props}/>}/>
+          <Route exact path="/ecommerce/paymenttypes" render={props => <PaymentTypes {...props} />} />
+          <Route exact path="/ecommerce/paymenttypes/:paymentTypeId(\d+)" render={props => <PaymentTypeDetail {...props} />} />
         </Switch>
       </>
     )

--- a/src/components/ecommerce/customers/customerDetail.js
+++ b/src/components/ecommerce/customers/customerDetail.js
@@ -118,7 +118,7 @@ class CustomerDetail extends Component {
                   <ListGroup>
                     {
                       customer.product.map((product, i) => {
-                        return <ListGroupItem key={i}>{product.title}</ListGroupItem>
+                        return <ListGroupItem key={i} tag="a" href={`/ecommerce/products/${product.id}`} action>{product.title}</ListGroupItem>
                       })
                     }
                   </ListGroup>
@@ -128,7 +128,7 @@ class CustomerDetail extends Component {
           }
         </Col>
         <Col lg={6} className="mb-4">
-          <h3>Payment Types</h3>
+          <h3>Used Payment Types</h3>
           <CustomInput onChange={this.onChangeToggle} type="switch" id="paymentsSwitch" name="customSwitch" label="Include Payment Types" className="mb-3" />
           {
             this.state.paymentsSwitch
@@ -137,7 +137,7 @@ class CustomerDetail extends Component {
                   <ListGroup>
                     {
                       customer.used_paymenttypes.map((payment, i) => {
-                        return <ListGroupItem key={i}>{payment.name}</ListGroupItem>
+                        return <ListGroupItem key={i} tag="a" action href={`/ecommerce/paymenttypes/${payment.id}`}>{payment.name}</ListGroupItem>
                       })
                     }
                   </ListGroup>

--- a/src/components/ecommerce/payment_types/newPaymentType.js
+++ b/src/components/ecommerce/payment_types/newPaymentType.js
@@ -1,3 +1,8 @@
+/**
+ * Handles displaying the New Payment Type Form
+ * Author: Sebastian Civarolo
+ */
+
 import React, { Component } from "react"
 import {
   Row,

--- a/src/components/ecommerce/payment_types/newPaymentType.js
+++ b/src/components/ecommerce/payment_types/newPaymentType.js
@@ -1,0 +1,25 @@
+import React, { Component } from "react"
+import {
+  Row,
+  Col,
+  Container
+} from "reactstrap"
+import PaymentTypeForm from "./paymentTypeForm"
+
+
+class NewPaymentType extends Component {
+  render() {
+    return (
+      <Container>
+        <Row>
+          <Col className="mb-5">
+            <h1>New Payment Type</h1>
+          </Col>
+        </Row>
+        <PaymentTypeForm {...this.props} />
+      </Container>
+    )
+  }
+}
+
+export default NewPaymentType

--- a/src/components/ecommerce/payment_types/paymentListItem.js
+++ b/src/components/ecommerce/payment_types/paymentListItem.js
@@ -1,3 +1,8 @@
+/**
+ * Handles displaying a single payment type on the main payment types view
+ * Author: Sebastian Civarolo
+ */
+
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 

--- a/src/components/ecommerce/payment_types/paymentListItem.js
+++ b/src/components/ecommerce/payment_types/paymentListItem.js
@@ -1,0 +1,39 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+import {
+  Row,
+  Col,
+  ListGroupItem,
+} from "reactstrap"
+
+class PaymentListItem extends Component {
+  state = {  }
+  render() {
+
+    const { paymentType } = this.props
+
+    return (
+      <ListGroupItem className="mb-3" tag="a" href={`paymenttypes/${paymentType.id}`} action>
+        <Row>
+          <Col lg={2}>
+            <h6>{paymentType.customer_id}</h6>
+          </Col>
+          <Col lg={4}>
+            <h6>{paymentType.name}</h6>
+          </Col>
+          <Col lg={3}>
+            <h6>{`***${paymentType.account_number.toString().slice(-4)}`}</h6>
+          </Col>
+          <Col lg={3}><h6>{paymentType.delete_date}</h6></Col>
+        </Row>
+      </ListGroupItem>
+    )
+  }
+}
+
+export default PaymentListItem
+
+PaymentListItem.propTypes = {
+  paymentType: PropTypes.object.isRequired,
+}

--- a/src/components/ecommerce/payment_types/paymentTypeDetail.js
+++ b/src/components/ecommerce/payment_types/paymentTypeDetail.js
@@ -1,0 +1,10 @@
+import React, { Component } from "react"
+
+class PaymentTypeDetail extends Component {
+  state = {  }
+  render() {
+    return ( <div>Payment Type Detail</div> )
+  }
+}
+
+export default PaymentTypeDetail

--- a/src/components/ecommerce/payment_types/paymentTypeDetail.js
+++ b/src/components/ecommerce/payment_types/paymentTypeDetail.js
@@ -1,10 +1,101 @@
 import React, { Component } from "react"
+import PropTypes from "prop-types"
+import {
+  Button,
+  Container,
+  Row,
+  Col,
+} from "reactstrap"
+
+import APICalls from "../../../modules/APICalls"
+import PaymentTypeForm from "./paymentTypeForm"
 
 class PaymentTypeDetail extends Component {
-  state = {  }
+
+  state = {
+    paymentType: {},
+    editSwitch: false
+  }
+
+  componentDidMount() {
+    return this.loadPaymentType(this.props.match.params.paymentTypeId)
+  }
+
+  loadPaymentType = (paymentTypeId) => {
+    return APICalls.getOneFromCategory("paymenttypes", paymentTypeId)
+      .then(paymentType => this.setState({paymentType}))
+  }
+
+  toggleEdit = () => {
+    this.setState({editSwitch: !this.state.editSwitch})
+  }
+
+  pageHeading = () => {
+    return (
+      <>
+        <Row>
+          <Col className="mb-5">
+            <h1>Payment Type Detail</h1>
+          </Col>
+          <Col className="text-right">
+            <Button color="primary" id="editSwitch" onClick={this.toggleEdit}>
+              {this.state.editSwitch ? "Cancel Edit" : "Edit Payment Type"}
+            </Button>
+          </Col>
+        </Row>
+        <Row>
+        </Row>
+      </>
+    )
+  }
+
+  paymentTypeRender = (paymentType) => {
+    return (
+      <Row>
+        <dl className="col-md-3">
+          <dt>Customer</dt>
+          <dd><a href={`/ecommerce/customers/${paymentType.customer_id}`}>{paymentType.customer_id}</a></dd>
+        </dl>
+        <dl className="col-md-3">
+          <dt>Payment Name</dt>
+          <dd>{paymentType.name}</dd>
+        </dl>
+        <dl className="col-md-3">
+          <dt>Account Number</dt>
+          { paymentType.account_number
+            ? <dd>{`***${paymentType.account_number.toString().slice(-4)}`}</dd>
+            : null
+          }
+        </dl>
+        <dl className="col-md-3">
+          <dt>Delete Date</dt>
+          <dd>{paymentType.delete_date}</dd>
+        </dl>
+      </Row>
+    )
+  }
+
   render() {
-    return ( <div>Payment Type Detail</div> )
+    const {paymentType} = this.state
+
+    return (
+      <Container>
+        {this.pageHeading()}
+
+        {
+          paymentType.detail
+            ? <h1>No PaymentType Found</h1>
+            : this.state.editSwitch
+              ? <PaymentTypeForm paymentType={paymentType} toggleEdit={this.toggleEdit} loadPaymentType={this.loadPaymentType} />
+              : this.paymentTypeRender(this.state.paymentType)
+        }
+      </Container>
+    )
   }
 }
 
 export default PaymentTypeDetail
+
+PaymentTypeDetail.propTypes = {
+  match: PropTypes.object.isRequired
+}

--- a/src/components/ecommerce/payment_types/paymentTypeDetail.js
+++ b/src/components/ecommerce/payment_types/paymentTypeDetail.js
@@ -1,3 +1,8 @@
+/**
+ * Handles displaying a single payment type detail page.
+ * Author: Sebastian Civarolo
+ */
+
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 import {

--- a/src/components/ecommerce/payment_types/paymentTypeForm.js
+++ b/src/components/ecommerce/payment_types/paymentTypeForm.js
@@ -1,0 +1,114 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+import {
+  Row,
+  Col,
+  Form,
+  FormGroup,
+  Label,
+  Input,
+  Button
+} from "reactstrap"
+import APICalls from "../../../modules/APICalls"
+
+class PaymentTypeForm extends Component {
+
+  state = {
+    customer: "",
+    name: "",
+    account_number: "",
+    delete_date: "",
+  }
+
+  componentDidMount() {
+    APICalls.getAllFromCategory("customers")
+      .then((customers) => {this.setState({customers})})
+    if (this.props.paymentType) {
+      for (let key in this.props.paymentType) {
+        this.setState({[key]: this.props.paymentType[key]})
+      }
+    }
+  }
+
+  handleFieldChange = e => {
+    const newState = {}
+    newState[e.target.id] = e.target.value
+    this.setState(newState)
+  }
+
+  submitForm = (e, data) => {
+    e.preventDefault()
+    let obj = {}
+    for (let key in data) {
+      if (key !== "customer_id" && key !== "customers") {
+        obj[key] = data[key]
+      }
+    }
+    obj.delete_date = obj.delete_date || null
+    if (this.props.paymentType) {
+      return APICalls.update("paymenttypes", obj, this.props.paymentType.id)
+        .then(paymentType => this.props.loadPaymentType(paymentType.id))
+        .then(() => this.props.toggleEdit())
+    } else {
+      return APICalls.post("paymenttypes", obj)
+        .then(() => this.props.history.push("/ecommerce/paymenttypes"))
+    }
+  }
+
+  render() {
+    return (
+      <Form onSubmit={e => this.submitForm(e, this.state)} onChange={this.handleFieldChange}>
+        <Row form>
+          <Col md={6}>
+            <FormGroup>
+              <Label for="customer">Customer</Label>
+              <Input type="select" name="customer" id="customer" required={true} defaultValue={this.state.customer.url}>
+                {
+                  this.state.customers
+                    ? this.state.customers.map((customer, i) => {
+                      if (customer.id === this.state.customer_id) {
+                        return (<option key={i} id={customer.id} value={customer.url} selected={true}>{customer.id} {customer.first_name} {customer.last_name}</option>)
+                      }
+                      return (<option key={i} id={customer.id} value={customer.url}>{customer.id} {customer.first_name} {customer.last_name}</option>)
+                    })
+                    : null
+                }
+              </Input>
+            </FormGroup>
+          </Col>
+          <Col md={6}>
+            <FormGroup>
+              <Label for="name">Payment Name</Label>
+              <Input type="text" name="name" id="name" required={true} defaultValue={this.state.name} />
+            </FormGroup>
+          </Col>
+          <Col md={6}>
+            <FormGroup>
+              <Label for="account_number">Account Number</Label>
+              <Input type="number" name="account_number" id="account_number" defaultValue={this.state.account_number} required={true} />
+            </FormGroup>
+          </Col>
+          <Col md={6}>
+            <FormGroup>
+              <Label for="delete_date">Delete Date</Label>
+              <Input type="datetime-local" name="delete_date" id="delete_date" defaultValue={this.state.delete_date} />
+            </FormGroup>
+          </Col>
+          <Col>
+            <Button type="submit">Save Changes</Button>
+          </Col>
+        </Row>
+      </Form>
+    )
+  }
+
+}
+
+export default PaymentTypeForm
+
+PaymentTypeForm.propTypes = {
+  paymentType: PropTypes.object,
+  loadPaymentType: PropTypes.func,
+  toggleEdit: PropTypes.func,
+  history: PropTypes.object.isRequired,
+}

--- a/src/components/ecommerce/payment_types/paymentTypeForm.js
+++ b/src/components/ecommerce/payment_types/paymentTypeForm.js
@@ -1,3 +1,8 @@
+/**
+ * Displays the form for editing or creating a new payment type
+ * Author: Sebastian Civarolo
+ */
+
 import React, { Component } from "react"
 import PropTypes from "prop-types"
 import {

--- a/src/components/ecommerce/payment_types/paymentTypes.js
+++ b/src/components/ecommerce/payment_types/paymentTypes.js
@@ -5,7 +5,12 @@ import {
   Row,
   Col,
   Button,
+  ListGroup,
+  ListGroupItem,
 } from "reactstrap"
+
+import PaymentListItem from "./paymentListItem"
+
 class PaymentTypes extends Component {
   state = {
     paymentTypes: []
@@ -16,6 +21,30 @@ class PaymentTypes extends Component {
       .then(paymentTypes => this.setState({paymentTypes}))
   }
 
+  paymentList = (paymentTypes) => {
+    return (
+      <ListGroup>
+        <ListGroupItem color="info">
+          <Row>
+            <Col lg={2}><h6>Customer</h6></Col>
+            <Col lg={4}><h6>Payment Name</h6></Col>
+            <Col lg={3}><h6>Account Number</h6></Col>
+            <Col lg={3}><h6>Delete Date</h6></Col>
+          </Row>
+        </ListGroupItem>
+        {
+          paymentTypes
+            ? paymentTypes.map((payment, i) => {
+              return (
+                <PaymentListItem key={i} paymentType={payment} />
+              )
+            })
+            : null
+        }
+      </ListGroup>
+    )
+  }
+
   render() {
     return (
       <Container className="mb-5">
@@ -24,19 +53,18 @@ class PaymentTypes extends Component {
             <h1>Payment Types</h1>
           </Col>
           <Col className="mb-3" lg={6}>
-            <div className="ml-auto">
-              <Button className="ml-2 mb-3" color="success" tag="a" href="/ecommerce/customers/new">Create New Customer</Button>
+            <div className="ml-auto text-right">
+              <Button className="ml-2 mb-3" color="success" tag="a" href="/ecommerce/paymenttypes/new">Create New Payment Type</Button>
             </div>
           </Col>
         </Row>
         <Row>
           <Col>
-            {/* {
-              this.state.displayingSearchResults && !this.state.customers.length
-                ? <h4>{`No results matching "${this.state.searchQuery}"`}</h4>
-                : this.CustomersList(this.state.customers)
-
-            } */}
+            {
+              this.state.paymentTypes.length
+                ? this.paymentList(this.state.paymentTypes)
+                : "There are no payment types in the database."
+            }
           </Col>
         </Row>
       </Container>

--- a/src/components/ecommerce/payment_types/paymentTypes.js
+++ b/src/components/ecommerce/payment_types/paymentTypes.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react"
+import APICalls from "../../../modules/APICalls"
+import {
+  Container,
+  Row,
+  Col,
+  Button,
+} from "reactstrap"
+class PaymentTypes extends Component {
+  state = {
+    paymentTypes: []
+  }
+
+  componentDidMount() {
+    APICalls.getAllFromCategory("paymenttypes")
+      .then(paymentTypes => this.setState({paymentTypes}))
+  }
+
+  render() {
+    return (
+      <Container className="mb-5">
+        <Row>
+          <Col className="mb-3" lg={6}>
+            <h1>Payment Types</h1>
+          </Col>
+          <Col className="mb-3" lg={6}>
+            <div className="ml-auto">
+              <Button className="ml-2 mb-3" color="success" tag="a" href="/ecommerce/customers/new">Create New Customer</Button>
+            </div>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            {/* {
+              this.state.displayingSearchResults && !this.state.customers.length
+                ? <h4>{`No results matching "${this.state.searchQuery}"`}</h4>
+                : this.CustomersList(this.state.customers)
+
+            } */}
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default PaymentTypes

--- a/src/components/ecommerce/payment_types/paymentTypes.js
+++ b/src/components/ecommerce/payment_types/paymentTypes.js
@@ -1,3 +1,8 @@
+/**
+ * Displays a list of payment types
+ * Author: Sebastian Civarolo
+ */
+
 import React, { Component } from "react"
 import APICalls from "../../../modules/APICalls"
 import {


### PR DESCRIPTION
# Description
Adds the payment type views.

## Related Ticket(s)
closes #28 
closes #29 
closes #30 
closes #49 

## Steps to Test Solution

1. View all payment types `http://localhost:3000/ecommerce/paymenttypes`
2. View payment type detail `http://localhost:3000/ecommerce/paymenttypes/1`
3. Edit a payment type
4. Create a new payment type
5. On a Customer Detail `http://localhost:3000/ecommerce/customers/1` you should be able to click payments or products and go to their respective detail page.

## Documentation
- [ ] There is new documentation in this pull request that must be reviewed..
- [x] I added documentation for any new classes/methods
- [ ] I updated the README

## Deploy Notes
